### PR TITLE
✨ feat(be[mlflow]): readable nested run names by execution order

### DIFF
--- a/src/app/core/pipeline_engine.py
+++ b/src/app/core/pipeline_engine.py
@@ -6,6 +6,10 @@ from typing import Any
 import mlflow
 
 from app.config.config import EXPERIMENT_NAME
+from app.core.plugin_discovery.naming import (
+    format_step_run_name,
+    make_plugin_display_name,
+)
 from app.core.plugin_discovery.plugin_manager import PluginManager
 from utils.plugin_notifier import PluginNotifier
 
@@ -75,6 +79,32 @@ class PipelineEngine:
         mlflow.end_run()
         return self._parent_run_id
 
+    def _next_execution_order(self) -> int:
+        """Return the 1-based execution position of the next nested step.
+
+        Counts the nested runs already attached to the active parent run
+        (via the ``mlflow.parentRunId`` tag) and adds one.  This is the
+        single source of truth that works both in batch mode and across
+        separate phase-2 ``execute-step`` calls, neither of which keeps
+        an in-memory counter.
+
+        Note:
+            If two phase-2 steps are executed concurrently on the same
+            parent run they may read the same count and receive the same
+            number.  MLflow run names need not be unique, so this is
+            tolerated rather than locked against.
+
+        Returns:
+            int: The next 1-based execution order.
+        """
+        client = mlflow.tracking.MlflowClient()
+        parent = client.get_run(self._parent_run_id)
+        children = client.search_runs(
+            experiment_ids=[parent.info.experiment_id],
+            filter_string=f"tags.`mlflow.parentRunId` = '{self._parent_run_id}'",
+        )
+        return len(children) + 1
+
     def execute_step(
         self,
         plugin_name: str,
@@ -111,9 +141,13 @@ class PipelineEngine:
         if notifier is not None:
             plugin.notifier = notifier
 
+        order = self._next_execution_order()
+        display_name = plugin.name or make_plugin_display_name(plugin_name)
+        run_name = format_step_run_name(plugin_name, display_name, order)
+
         with (
             mlflow.start_run(run_id=self._parent_run_id),
-            mlflow.start_run(run_name=plugin_name, nested=True) as step_run,
+            mlflow.start_run(run_name=run_name, nested=True) as step_run,
         ):
             plugin.load_context(context)
             plugin.run(**params)

--- a/src/app/core/plugin_discovery/naming.py
+++ b/src/app/core/plugin_discovery/naming.py
@@ -1,0 +1,55 @@
+"""Human-readable naming helpers for plugins and pipeline steps.
+
+Centralises the two ways a dotted plugin module path is turned into a
+label so the plugin registry and the pipeline engine share one
+definition.
+"""
+
+from app.config.config import PLUGIN_CATEGORIES
+
+
+def make_plugin_display_name(plugin_module_path: str) -> str:
+    """Derive a human-readable display name from a dotted module path.
+
+    Takes the second-to-last segment (the implementation directory name)
+    and converts it from snake_case to Title Case.
+
+    Args:
+        plugin_module_path: Dotted module path
+            (e.g. ``dataset_loading.movieLens_loader.movieLens_loader``).
+
+    Returns:
+        str: Human-readable name (e.g. ``Movielens Loader``).
+    """
+    parts = plugin_module_path.split(".")
+    impl_name = parts[-2]
+    return impl_name.replace("_", " ").title()
+
+
+def format_step_run_name(
+    plugin_name: str,
+    plugin_display_name: str,
+    execution_order: int,
+) -> str:
+    """Build the display name for a nested (plugin execution) MLflow run.
+
+    Produces ``[<execution_order>] <category> / <plugin>``, e.g.
+    ``[5] Labeling Evaluation / Embedding Map``.  The bracket number is
+    the execution sequence of the step within its parent pipeline run
+    (not the category's static config order).
+
+    Args:
+        plugin_name: Dotted plugin module path
+            (e.g. ``dataset_loading.movieLens_loader.movieLens_loader``).
+        plugin_display_name: Human-readable plugin name.
+        execution_order: 1-based position of this step within the
+            parent pipeline run.
+
+    Returns:
+        str: The formatted nested-run name.  Falls back to the raw
+            category key when the category is unknown.
+    """
+    category = plugin_name.split(".")[0]
+    info = PLUGIN_CATEGORIES.get(category)
+    category_label = info.display_name if info is not None else category
+    return f"[{execution_order}] {category_label} / {plugin_display_name}"

--- a/src/app/core/plugin_discovery/plugin_registry.py
+++ b/src/app/core/plugin_discovery/plugin_registry.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from app.config.config import PLUGIN_CATEGORIES
+from app.core.plugin_discovery.naming import make_plugin_display_name
 from app.core.plugin_discovery.plugin_manager import PluginManager
 from app.models.plugin import (
     ArtifactDisplayModel,
@@ -270,24 +271,6 @@ def _find_plugin_modules(category_dir: Path, prefix: str) -> list[str]:
     return modules
 
 
-def _make_display_name(plugin_module_path: str) -> str:
-    """Derive a human-readable display name from a dotted module path.
-
-    Takes the second-to-last segment (the implementation directory name)
-    and converts it from snake_case to Title Case.
-
-    Args:
-        plugin_module_path: Dotted module path
-            (e.g. ``dataset_loading.movieLens_loader.movieLens_loader``).
-
-    Returns:
-        str: Human-readable name (e.g. ``Movieles Loader``).
-    """
-    parts = plugin_module_path.split(".")
-    impl_name = parts[-2]
-    return impl_name.replace("_", " ").title()
-
-
 def _convert_display_spec(
     spec: "DisplaySpec | None",
 ) -> ItemRowsDisplayModel | ArtifactDisplayModel | None:
@@ -355,7 +338,7 @@ def _discover_implementations(
             category_name,
             module_path,
         )
-        display_name = plugin_instance.name or _make_display_name(module_path)
+        display_name = plugin_instance.name or make_plugin_display_name(module_path)
         display = _convert_display_spec(plugin_instance.io_spec.display)
         kind = _derive_kind(module_path, category_name)
         implementations.append(

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -80,7 +80,7 @@ below yourself — the engine calls them, in order (§4). You only
 
 | Attr | Default | Role |
 |------|---------|------|
-| `name` | `None` | Human label for the UI. When `None`, the registry derives one from the directory name (`_make_display_name`, `plugin_registry.py`). |
+| `name` | `None` | Human label for the UI. When `None`, the registry derives one from the directory name (`make_plugin_display_name`, `plugin_discovery/naming.py`). |
 | `io_spec` | shared `PluginIOSpec()` | The I/O contract. **Always declare your own** (see §8). |
 | `notifier` | `NullNotifier()` | Progress channel. The engine swaps in a real `PluginNotifier` before `run()`; outside a pipeline it stays a silent no‑op, so the same code runs in tests unchanged. |
 
@@ -476,7 +476,7 @@ These are real, code‑traced sharp edges — read before authoring.
   as a class attribute — do the same. (`BaseComparePlugin` mutates the
   spec safely via `dataclasses.replace`, not in place.)
 - **`name` is optional but recommended.** Without it the UI label is
-  the directory name title‑cased (`_make_display_name`), e.g.
+  the directory name title‑cased (`make_plugin_display_name`), e.g.
   `movieLens_loader` → `Movielens Loader`. Set `name` for a clean
   label.
 

--- a/src/tests/app/unit/test_pipeline_engine.py
+++ b/src/tests/app/unit/test_pipeline_engine.py
@@ -26,6 +26,23 @@ def _mock_start_run(run_id: str = "parent_id") -> MagicMock:
     return mock_run
 
 
+def _arm_execution_order(mock_mlflow: MagicMock, existing: int = 0) -> None:
+    """Make ``_next_execution_order`` resolve under a mocked ``mlflow``.
+
+    ``_next_execution_order`` counts the parent run's existing nested
+    children via ``MlflowClient.search_runs`` and adds one.  Under a bare
+    mock, ``search_runs`` returns a ``MagicMock`` that ``len()`` rejects,
+    so tests must supply a concrete list.
+
+    Args:
+        mock_mlflow: The patched ``mlflow`` module mock.
+        existing: How many nested children already exist (the next
+            execution order becomes ``existing + 1``).
+    """
+    client = mock_mlflow.tracking.MlflowClient.return_value
+    client.search_runs.return_value = [MagicMock() for _ in range(existing)]
+
+
 class TestStartRun:
     """Tests for PipelineEngine.start_run."""
 
@@ -120,6 +137,7 @@ class TestExecuteStep:
             _mock_start_run("parent_id"),
             _mock_start_run("step_id"),
         ]
+        _arm_execution_order(mock_mlflow)
 
         engine = PipelineEngine()
         engine.start_run()
@@ -131,6 +149,38 @@ class TestExecuteStep:
 
     @patch("app.core.pipeline_engine.PluginManager")
     @patch("app.core.pipeline_engine.mlflow")
+    def test_nested_run_name_uses_execution_order(
+        self,
+        mock_mlflow: MagicMock,
+        mock_pm: MagicMock,
+    ) -> None:
+        """Verify the nested run name is '[<order>] <category> / <plugin>'.
+
+        The bracket number is the execution sequence (existing children
+        + 1), not the category's config order; the plugin's own ``name``
+        is preferred for the label.
+        """
+        mock_mlflow.start_run.side_effect = [
+            _mock_start_run("parent_id"),
+            _mock_start_run("parent_id"),
+            _mock_start_run("step_id"),
+        ]
+        # Three nested children already exist → this step is the 4th.
+        _arm_execution_order(mock_mlflow, existing=3)
+        mock_plugin = MagicMock()
+        mock_plugin.name = "MovieLens Loader"
+        mock_pm.load.return_value = mock_plugin
+
+        engine = PipelineEngine()
+        engine.start_run()
+        engine.execute_step("dataset_loading.movieLens_loader.movieLens_loader", {}, {})
+
+        nested_call = mock_mlflow.start_run.call_args_list[-1]
+        assert nested_call.kwargs["nested"] is True
+        assert nested_call.kwargs["run_name"] == "[4] Dataset Loading / MovieLens Loader"
+
+    @patch("app.core.pipeline_engine.PluginManager")
+    @patch("app.core.pipeline_engine.mlflow")
     def test_calls_plugin_run_with_params(self, mock_mlflow: MagicMock, mock_pm: MagicMock) -> None:
         """Verify plugin.run() is called with only keyword params."""
         mock_mlflow.start_run.side_effect = [
@@ -138,6 +188,7 @@ class TestExecuteStep:
             _mock_start_run("parent_id"),
             _mock_start_run("step_id"),
         ]
+        _arm_execution_order(mock_mlflow)
         mock_plugin = MagicMock()
         mock_pm.load.return_value = mock_plugin
 
@@ -162,6 +213,7 @@ class TestExecuteStep:
             _mock_start_run("parent_id"),
             _mock_start_run("step_id"),
         ]
+        _arm_execution_order(mock_mlflow)
         mock_plugin = MagicMock()
         mock_pm.load.return_value = mock_plugin
 
@@ -186,6 +238,7 @@ class TestExecuteStep:
             _mock_start_run("parent_id"),
             _mock_start_run("step_id"),
         ]
+        _arm_execution_order(mock_mlflow)
         mock_plugin = MagicMock()
         mock_pm.load.return_value = mock_plugin
 
@@ -208,6 +261,7 @@ class TestExecuteStep:
             _mock_start_run("parent_id"),
             _mock_start_run("step_id"),
         ]
+        _arm_execution_order(mock_mlflow)
         call_order: list[str] = []
         mock_plugin = MagicMock()
         mock_plugin.load_context.side_effect = (
@@ -242,6 +296,7 @@ class TestExecuteStep:
             _mock_start_run("parent_id"),
             _mock_start_run("step_id"),
         ]
+        _arm_execution_order(mock_mlflow)
 
         engine = PipelineEngine()
         engine.start_run()
@@ -264,6 +319,7 @@ class TestExecuteStep:
             _mock_start_run("parent_id"),
             _mock_start_run("step_id"),
         ]
+        _arm_execution_order(mock_mlflow)
         mock_plugin = MagicMock()
         mock_pm.load.return_value = mock_plugin
         notifier = PluginNotifier()
@@ -287,6 +343,7 @@ class TestExecuteStep:
             _mock_start_run("parent_id"),
             _mock_start_run("step_id"),
         ]
+        _arm_execution_order(mock_mlflow)
         mock_plugin = MagicMock()
         original_notifier = mock_plugin.notifier
         mock_pm.load.return_value = mock_plugin
@@ -312,6 +369,7 @@ class TestExecuteStep:
             _mock_start_run("parent_id"),
             _mock_start_run("step_id"),
         ]
+        _arm_execution_order(mock_mlflow)
         notifier = PluginNotifier()
         seen_notifier: list[Any] = []
 
@@ -403,6 +461,7 @@ class TestResumeRun:
     def test_allows_execute_step_after_resume(self, mock_mlflow: MagicMock) -> None:
         """Verify execute_step works after resume_run."""
         mock_mlflow.start_run.return_value = _mock_start_run("step_id")
+        _arm_execution_order(mock_mlflow)
 
         engine = PipelineEngine()
         engine.resume_run("parent_id")

--- a/src/tests/app/unit/test_plugin_registry.py
+++ b/src/tests/app/unit/test_plugin_registry.py
@@ -11,13 +11,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.core.plugin_discovery.naming import make_plugin_display_name
 from app.core.plugin_discovery.plugin_registry import (
     _build_ui_hint_map,
     _convert_display_spec,
     _derive_kind,
     _extract_parameters_from_instance,
     _find_plugin_modules,
-    _make_display_name,
     _parse_annotation,
     _resolve_widget,
     get_plugin_registry,
@@ -412,7 +412,7 @@ class TestDeriveKind:
 
 
 class TestMakeDisplayName:
-    """Tests for _make_display_name (pure function, no mocking needed)."""
+    """Tests for make_plugin_display_name (pure function, no mocking needed)."""
 
     @pytest.mark.parametrize(
         ("module_path", "expected"),
@@ -429,7 +429,7 @@ class TestMakeDisplayName:
             module_path: Dotted plugin module path.
             expected: Expected human-readable display name.
         """
-        assert _make_display_name(module_path) == expected
+        assert make_plugin_display_name(module_path) == expected
 
 
 class TestDiscoverImplementationsDisplayName:


### PR DESCRIPTION
Rename plugin-execution nested runs from the dotted module path to "[<execution order>] <category> / <plugin>" (e.g.
"[1] Dataset Loading / MovieLens Loader"). The bracket number is the step's execution sequence within the parent run, computed from the parent's existing nested children, so it is correct in both batch and phase-2 (resume) modes.

- Add shared plugin_discovery/naming.py (make_plugin_display_name moved out of plugin_registry; new format_step_run_name)
- Add PipelineEngine._next_execution_order and use the formatted name in execute_step