### PR TITLE
✨ feat(mlflow): recover zombie runs left RUNNING by a killed backend

### DIFF
--- a/src/app/core/run_recovery.py
+++ b/src/app/core/run_recovery.py
@@ -1,0 +1,68 @@
+"""Reconcile MLflow runs left ``RUNNING`` by a force-terminated backend.
+
+A parent pipeline run (and its in-flight child step) is ``RUNNING`` only while
+a step executes.  Force-killing the process mid-step — SIGKILL, OOM-killer,
+``docker kill`` — skips the MLflow context manager's ``__exit__``, stranding
+both runs as ``RUNNING`` forever.  This module sweeps such runs to ``FAILED``.
+
+The sweep marks *every* ``RUNNING`` run in the experiment, which is safe only
+because a single backend instance owns it (running two against one tracking
+server would let one stomp the other's in-flight runs).
+"""
+
+import mlflow
+from mlflow.entities import ViewType
+
+from app.config.config import EXPERIMENT_NAME
+from app.utils.logger import logger
+
+#: Tag key recorded on each recovered run so the MLflow UI distinguishes a
+#: force-terminated zombie from a genuine in-pipeline failure.
+RECOVERY_TAG = "sarssa.recovery"
+
+
+def fail_orphaned_runs(reason: str) -> list[str]:
+    """Terminate every ``RUNNING`` run in the experiment as ``FAILED``.
+
+    Args:
+        reason: Short marker recorded under the :data:`RECOVERY_TAG` tag on
+            each terminated run (e.g. ``"terminated_at_shutdown"``).
+
+    Returns:
+        list[str]: The run IDs that were terminated.
+    """
+    experiment = mlflow.get_experiment_by_name(EXPERIMENT_NAME)
+    if experiment is None:
+        return []
+
+    client = mlflow.tracking.MlflowClient()
+    terminated: list[str] = []
+    page_token: str | None = None
+    while True:
+        page = client.search_runs(
+            experiment_ids=[experiment.experiment_id],
+            filter_string="attributes.status = 'RUNNING'",
+            run_view_type=ViewType.ACTIVE_ONLY,
+            max_results=1000,
+            page_token=page_token,
+        )
+        for run in page:
+            run_id = run.info.run_id
+            try:
+                client.set_tag(run_id, RECOVERY_TAG, reason)
+                client.set_terminated(run_id, status="FAILED")
+                terminated.append(run_id)
+            except Exception:
+                logger.exception("[RECOVERY] Could not terminate orphaned run %s", run_id)
+        page_token = page.token
+        if not page_token:
+            break
+
+    if terminated:
+        logger.warning(
+            "[RECOVERY] Marked %d orphaned RUNNING run(s) as FAILED (%s): %s",
+            len(terminated),
+            reason,
+            ", ".join(terminated),
+        )
+    return terminated

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,5 +1,8 @@
 """FastAPI application entry point."""
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 import mlflow
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -8,6 +11,7 @@ from app.api.routes_items import router as items_router
 from app.api.routes_pipelines import router as pipelines_router
 from app.api.routes_plugins import router as plugins_router
 from app.config.config import ARTIFACT_ROOT, EXPERIMENT_NAME, TRACKING_URI
+from app.core.run_recovery import fail_orphaned_runs
 
 mlflow.set_tracking_uri(TRACKING_URI)
 
@@ -18,7 +22,21 @@ mlflow.set_tracking_uri(TRACKING_URI)
 if mlflow.get_experiment_by_name(EXPERIMENT_NAME) is None:
     mlflow.create_experiment(EXPERIMENT_NAME, artifact_location=ARTIFACT_ROOT)
 
-app = FastAPI(title="Application for Recommender Systems with SAEs Service")
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    """Sweep zombie MLflow runs around the server lifecycle: at startup
+    (runs a previous hard kill stranded as RUNNING) and at graceful
+    shutdown (the run this process is abandoning)."""
+    fail_orphaned_runs("orphaned_at_startup")
+    yield
+    fail_orphaned_runs("terminated_at_shutdown")
+
+
+app = FastAPI(
+    title="Application for Recommender Systems with SAEs Service",
+    lifespan=lifespan,
+)
 
 app.add_middleware(
     CORSMiddleware,

--- a/src/tests/app/unit/test_main_lifespan.py
+++ b/src/tests/app/unit/test_main_lifespan.py
@@ -1,0 +1,21 @@
+"""Unit tests for the FastAPI lifespan run-recovery wiring."""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from app.main import lifespan
+
+
+@pytest.mark.asyncio
+async def test_lifespan_reconciles_on_startup_and_shutdown() -> None:
+    """Orphaned runs are swept on startup, then again on graceful shutdown."""
+    with patch("app.main.fail_orphaned_runs") as mock_fail:
+        async with lifespan(MagicMock()):
+            # Inside the context: startup has run, shutdown has not yet.
+            mock_fail.assert_called_once_with("orphaned_at_startup")
+
+        assert mock_fail.call_args_list == [
+            call("orphaned_at_startup"),
+            call("terminated_at_shutdown"),
+        ]

--- a/src/tests/app/unit/test_run_recovery.py
+++ b/src/tests/app/unit/test_run_recovery.py
@@ -1,0 +1,91 @@
+"""Unit tests for app.core.run_recovery.
+
+All MLflow interactions are mocked.
+"""
+
+from unittest.mock import MagicMock, call, patch
+
+from app.core.run_recovery import RECOVERY_TAG, fail_orphaned_runs
+
+
+class _Page(list):
+    """Stand-in for MLflow's PagedList: a list carrying a ``.token``."""
+
+    def __init__(self, runs: list, token: str | None = None) -> None:
+        super().__init__(runs)
+        self.token = token
+
+
+def _run(run_id: str) -> MagicMock:
+    """Create a mock run with the given ``info.run_id``."""
+    run = MagicMock()
+    run.info.run_id = run_id
+    return run
+
+
+def _arm(mock_mlflow: MagicMock, pages: list[_Page]) -> MagicMock:
+    """Wire ``mlflow`` so the experiment resolves and search returns *pages*.
+
+    Returns the mock ``MlflowClient`` instance for assertions.
+    """
+    mock_mlflow.get_experiment_by_name.return_value = MagicMock(experiment_id="1")
+    client = mock_mlflow.tracking.MlflowClient.return_value
+    client.search_runs.side_effect = pages
+    return client
+
+
+class TestFailOrphanedRuns:
+    """Tests for fail_orphaned_runs."""
+
+    @patch("app.core.run_recovery.mlflow")
+    def test_marks_running_runs_failed_with_tag(self, mock_mlflow: MagicMock) -> None:
+        """Each RUNNING run is tagged and terminated as FAILED."""
+        client = _arm(mock_mlflow, [_Page([_run("parent"), _run("child")])])
+
+        result = fail_orphaned_runs("terminated_at_shutdown")
+
+        assert result == ["parent", "child"]
+        client.set_tag.assert_has_calls(
+            [
+                call("parent", RECOVERY_TAG, "terminated_at_shutdown"),
+                call("child", RECOVERY_TAG, "terminated_at_shutdown"),
+            ]
+        )
+        client.set_terminated.assert_has_calls(
+            [call("parent", status="FAILED"), call("child", status="FAILED")]
+        )
+
+    @patch("app.core.run_recovery.mlflow")
+    def test_no_experiment_returns_empty(self, mock_mlflow: MagicMock) -> None:
+        """A missing experiment is a no-op, not an error."""
+        mock_mlflow.get_experiment_by_name.return_value = None
+
+        assert fail_orphaned_runs("terminated_at_shutdown") == []
+        mock_mlflow.tracking.MlflowClient.assert_not_called()
+
+    @patch("app.core.run_recovery.mlflow")
+    def test_no_running_runs_is_noop(self, mock_mlflow: MagicMock) -> None:
+        """An empty result set terminates nothing."""
+        client = _arm(mock_mlflow, [_Page([])])
+
+        assert fail_orphaned_runs("terminated_at_shutdown") == []
+        client.set_terminated.assert_not_called()
+
+    @patch("app.core.run_recovery.mlflow")
+    def test_paginates_until_token_exhausted(self, mock_mlflow: MagicMock) -> None:
+        """All pages are swept until ``token`` is falsy."""
+        client = _arm(
+            mock_mlflow,
+            [_Page([_run("a")], token="next"), _Page([_run("b")], token=None)],
+        )
+
+        assert fail_orphaned_runs("terminated_at_shutdown") == ["a", "b"]
+        assert client.search_runs.call_count == 2
+
+    @patch("app.core.run_recovery.mlflow")
+    def test_continues_after_failure_on_one_run(self, mock_mlflow: MagicMock) -> None:
+        """A failure terminating one run does not abort the sweep."""
+        client = _arm(mock_mlflow, [_Page([_run("bad"), _run("good")])])
+        client.set_terminated.side_effect = [RuntimeError("boom"), None]
+
+        assert fail_orphaned_runs("terminated_at_shutdown") == ["good"]


### PR DESCRIPTION
A FastAPI lifespan hook sweeps stranded RUNNING runs to FAILED on graceful shutdown (SIGTERM) and at startup, covering both clean stops and hard kills (SIGKILL, crash, power loss).